### PR TITLE
Showing loader before page renders

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -29,7 +29,8 @@ export default function HTML(props) {
         <noscript key="noscript" id="gatsby-noscript">
           This app works best with JavaScript enabled.
         </noscript>
-        <div key={`body`} id="___gatsby">
+        <div key={`body`} id="___gatsby">       
+          <p style={{textAlign: "center",marginTop: "300px",fontSize: "20px", color: "blue"}}>Loading...</p> 
           {props.body}
         </div>
         {props.postBodyComponents}


### PR DESCRIPTION
Fix for issue - On page load, source is displayed before being rendered #19061
